### PR TITLE
END { done_testing } defeats the point.

### DIFF
--- a/t/00-compile.t
+++ b/t/00-compile.t
@@ -1,4 +1,3 @@
-
 use strict;
 use warnings;
 
@@ -6,7 +5,6 @@ use FindBin;
 use lib map $FindBin::Bin . '/' . $_, qw( . ../lib ../lib/perl5 );
 
 use Test::More;
-END { done_testing }
 
 ######################################################################
 
@@ -52,4 +50,4 @@ use_ok ('SQL::Admin::Catalog::Table::Unique');
 use_ok ('SQL::Admin::Catalog::Table::ForeignKey');
 use_ok ('SQL::Admin::Catalog::Table::Column');
 
-
+done_testing;


### PR DESCRIPTION
Putting done_testing() in an END block defeats its protections.  done_testing should be called IF AND ONLY IF the test has run to completion.  END blocks always run.

I fixed one test, you can handle the rest.
